### PR TITLE
Add configurable storage, folder structure, and filename options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ data.json
 
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store
+
+# VS Code History
+.history

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "strava-activities",
-	"version": "2.1.0",
+	"version": "3.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "strava-activities",
-			"version": "2.1.0",
+			"version": "3.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"@electron/remote": "^2.0.11",


### PR DESCRIPTION
* Add Activities Folder setting to customize where Strava data is stored
* Add Activities Folder Format setting with {{date:FORMAT}} tokens for structured storage
  (e.g., "{{date:YYYY}}/{{date:MM}}" for year/month grouping)
* Support {{date:FORMAT}} tokens in daily note path format
  (e.g., "Daily Notes/{{date:YYYY}}/{{date:MM}}")
* Add toggle to enable/disable daily note links in synced activities
* Add filenameFormat setting with dropdown (Summary / Activity Name)
* Sanitize activity names for safe filenames across all platforms
* Update createFolderIfNonExistent to handle nested paths
* Fix settings migration to properly deep-merge nested objects